### PR TITLE
Update the install.sh url. (README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ brew install oath-toolkit
 ##### Automatic Installation:
 Install scripts just wraps the above mentioned commands, and cleans up.
 ```
-sudo curl -sL http://mimier.gowtham-sai.com/install.sh | bash
+sudo curl -sL https://raw.githubusercontent.com/gowtham-sai/mimier/master/install.sh | bash
 ```
 
 ##### Manual Installation:


### PR DESCRIPTION
## Background
 * The url given in the installation script is outdated. It doesn't route to the right `install.sh` file.
 * Instead, it routes to the ads page. I think it's because the domain name is expired. 

## What does this MR do? 
* I updated the installation script's URL to be using the `install.sh` script in this repository. This ensures that the installation script will always work (depends on Github).